### PR TITLE
added the top-level node-modules folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # dependencies
 /chowpronto_backend/node_modules
 /chowpronto_frontend/node_modules
+/node_modules
 
 # testing
 /coverage
@@ -22,4 +23,3 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-node_modules


### PR DESCRIPTION
This kept on coming up as an error in my terminal. Not sure why we need a node-modules folder at the parent level but this should stop the error anyway.